### PR TITLE
Improve the pip package

### DIFF
--- a/abfe_explicit.py
+++ b/abfe_explicit.py
@@ -1,3 +1,5 @@
+#! python
+
 from __future__ import print_function
 from __future__ import division
 import sys

--- a/rbfe_explicit.py
+++ b/rbfe_explicit.py
@@ -1,3 +1,5 @@
+#! python
+
 from __future__ import print_function
 from __future__ import division
 import sys

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,7 @@ setup(name=NAME,
       author_email=AUTHOR_EMAIL,
       py_modules=MODULES,
       scripts=SCRIPTS,
+      # Fake a package to include the config file
+      packages=['utils'], package_data={'utils': ['logging.conf']},
       requires=REQUIRES
      )

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import sys
-from distutils.core import setup
+from setuptools import setup
 from async_re import __version__ as VERSION
 
 NAME = 'async_re'
@@ -44,5 +43,6 @@ setup(name=NAME,
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       py_modules=MODULES,
+      scripts=SCRIPTS,
       requires=REQUIRES
      )


### PR DESCRIPTION
- [x] Include scripts (`abfe_explicit.py`, `rbfe_explicit.py`) into the pip package
- [x] Include the logging configuration (`utils/logging.conf`) into the pip package

This facilitates a direct installation from the repository:
```
pip install git+https://github.com/raimis/AToM-OpenMM@fix_package
```