### PR TITLE
Include structprep scripts with pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ NAME = 'async_re'
 MODULES = 'async_re', 'ommreplica', 'ommsystem', 'ommworker', 'local_openmm_transport', 'transport', 'gibbs_sampling', 'openmm_async_re'
 
 
-SCRIPTS = 'abfe_explicit.py', 'rbfe_explicit.py'
+SCRIPTS = 'abfe_explicit.py', 'rbfe_explicit.py', 'abfe_structprep.py', 'rbfe_structprep.py'
 
 REQUIRES = 'configobj', 'numpy'
 


### PR DESCRIPTION
Included both `abfe_structprep.py` and `rbfe_structprep.py` in the pip package.