### PR TITLE
V4.0.0rc-r1

### DIFF
--- a/abfe_structprep.py
+++ b/abfe_structprep.py
@@ -378,9 +378,27 @@ def massage_keywords(keywords, restrain_solutes = True):
     keywords['TIME_STEP'] = 0.001
 
     #restrain all solutes: receptor and ligands
-    nlig = len(keywords.get('LIGAND_ATOMS'))
-    last_lig_atom = int(keywords.get('LIGAND_ATOMS')[nlig-1])
-    keywords['POS_RESTRAINED_ATOMS'] = [i for i in range(last_lig_atom+1)]
+    lig_in_front = keywords.get('LIGAND_IN_BEGINNING')
+
+    lif=False
+    if lig_in_front==None:
+        print('INFO: LIGAND_IN_BEGINNING keyword not captured.')
+    else:
+        print('INFO: LIGAND_IN_BEGINNING keyword is now captured.')
+        if 'y' in lig_in_front or 'Y' in lig_in_front: # yes - ligand in the beginning
+           print('value is',lig_in_front)
+           lif=True
+    
+    if lif:
+        pass
+        natom_ca = len(keywords.get('POS_RESTRAINED_ATOMS'))
+        last_ca_atom = int(keywords.get('POS_RESTRAINED_ATOMS')[natom_ca-1])
+        #print('last CA atom is',last_ca_atom)
+        keywords['POS_RESTRAINED_ATOMS'] = [i for i in range(last_ca_atom+1)]
+    else:
+        nlig = len(keywords.get('LIGAND_ATOMS'))
+        last_lig_atom = int(keywords.get('LIGAND_ATOMS')[nlig-1])
+        keywords['POS_RESTRAINED_ATOMS'] = [i for i in range(last_lig_atom+1)]
 
 if __name__ == '__main__':
 

--- a/rbfe_structprep.py
+++ b/rbfe_structprep.py
@@ -386,9 +386,25 @@ def massage_keywords(keywords, restrain_solutes = True):
     keywords['TIME_STEP'] = 0.001
 
     #restrain all solutes: receptor and ligands
-    nlig2 = len(keywords.get('LIGAND2_ATOMS'))
-    last_lig2_atom = int(keywords.get('LIGAND2_ATOMS')[nlig2-1])
-    keywords['POS_RESTRAINED_ATOMS'] = [i for i in range(last_lig2_atom+1)]
+    lig_in_front = keywords.get('LIGAND_IN_BEGINNING')
+    
+    lif=False
+    if lig_in_front==None:
+        print('INFO: LIGAND_IN_BEGINNING keyword not captured.')
+    else:
+        print('INFO: LIGAND_IN_BEGINNING keyword is now captured.')
+        if 'y' in lig_in_front or 'Y' in lig_in_front: # yes - ligand in the beginning
+           print('value is',lig_in_front)
+           lif=True
+
+    if lif:
+        natom_ca = len(keywords.get('POS_RESTRAINED_ATOMS'))
+        last_ca_atom = int(keywords.get('POS_RESTRAINED_ATOMS')[natom_ca-1])
+        keywords['POS_RESTRAINED_ATOMS'] = [i for i in range(last_ca_atom+1)] 
+    else:
+        nlig2 = len(keywords.get('LIGAND2_ATOMS'))
+        last_lig2_atom = int(keywords.get('LIGAND2_ATOMS')[nlig2-1])
+        keywords['POS_RESTRAINED_ATOMS'] = [i for i in range(last_lig2_atom+1)]
 
 if __name__ == '__main__':
 
@@ -419,6 +435,7 @@ if __name__ == '__main__':
     massage_keywords(keywords, restrain_solutes)
     
     do_mintherm(keywords, logger)
+
     do_lambda_annealing(keywords, logger)
 
     #reestablish the restrained atoms


### PR DESCRIPTION
try to add:

1. use positional restraint for ligand(s) to replace the binding site-ligand CM-CM restraint while CM_KF is set to negative value;
2. allow ligands to be put ahead of protein via LIGAND_IN_BEGINNING keyword (by default is immediately after protein).