### PR TITLE
Use xtc to reduce trajectory volume and fix shebang.

### DIFF
--- a/abfe_structprep.py
+++ b/abfe_structprep.py
@@ -243,7 +243,7 @@ def do_lambda_annealing(keywords, logger):
     number_of_cycles = int(totalSteps/steps_per_cycle)
     deltalambda = (0.5 - 0.0)/float(number_of_cycles)
     simulation.reporters.append(StateDataReporter(stdout, steps_per_cycle, step=True, potentialEnergy = True, temperature=True))
-    simulation.reporters.append(DCDReporter(jobname + "_mdlambda.dcd", steps_per_cycle))
+    simulation.reporters.append(XTCReporter(jobname + "_mdlambda.xtc", steps_per_cycle))
 
     state = simulation.context.getState(getEnergy = True)
     print("Potential Energy =", state.getPotentialEnergy())
@@ -359,7 +359,7 @@ def do_equil(keywords, logger):
     totalSteps = 150000
     steps_per_cycle = 5000
     simulation.reporters.append(StateDataReporter(stdout, steps_per_cycle, step=True, potentialEnergy = True, temperature=True))
-    simulation.reporters.append(DCDReporter(jobname + "_0.dcd", steps_per_cycle))
+    simulation.reporters.append(XTCReporter(jobname + "_0.xtc", steps_per_cycle))
 
     state = simulation.context.getState(getEnergy = True)
     print("Potential Energy =", state.getPotentialEnergy())

--- a/local_openmm_transport.py
+++ b/local_openmm_transport.py
@@ -223,7 +223,7 @@ class LocalOpenMMTransport(Transport):
         if mdsteps % job['nprnt'] == 0:
             ommreplica.save_out()
         if mdsteps % job['ntrj'] == 0:
-            ommreplica.save_dcd()
+            ommreplica.save_xtc()
         return 0
 
     def isDone(self,replica,cycle):

--- a/ommreplica.py
+++ b/ommreplica.py
@@ -43,7 +43,7 @@ class OMMReplica(object):
         self.open_out()
         #may override stateid, positions, etc.
         self.load_checkpoint()
-        self.open_dcd()
+        self.open_xtc()
 
     def set_state(self, stateid, par):
         self.stateid = int(stateid)
@@ -90,23 +90,24 @@ class OMMReplica(object):
         else:
            self.logger.warning("Refused attempt to save checkpoint file %s in unsafe mode. Remove file %s prior to writing checkpoints and restore it when done." % (ckptfile, self.safeckpt_file) )
 
-    def open_dcd(self):
-        dcdfilename =  'r%d/%s.dcd' % (self._id,self.basename)
-        append = os.path.isfile(dcdfilename)
+    def open_xtc(self):
+        xtcfilename =  'r%d/%s.xtc' % (self._id,self.basename)
+        interval = int(self.keywords.get('TRJ_FREQUENCY'))
+        append = os.path.isfile(xtcfilename)
         if append:
             mode = 'r+b'
         else:
             mode = 'wb'
-        self.dcdfile = open(dcdfilename, mode)
-        self.dcd = DCDFile(self.dcdfile, self.worker.topology, self.ommsystem.MDstepsize, append=append)
-        self.dcdfile.flush() # Force the writing of the DCD header
+        self.xtcfile = xtcfilename
+        self.xtc = XTCFile(self.xtcfile, self.worker.topology, self.ommsystem.MDstepsize, interval=interval, append=append)
 
-    def save_dcd(self):
+
+    def save_xtc(self):
         #TODO
         #boxsize options works only for NVT because the boxsize of the service worker
         #is not updated from the compute worker
         boxsize = self.worker.simulation.context.getState().getPeriodicBoxVectors()
-        self.dcd.writeModel(self.positions, periodicBoxVectors=boxsize)
+        self.xtc.writeModel(self.positions, periodicBoxVectors=boxsize)
 
     def set_mdsteps(self, mdsteps):
         self.mdsteps = mdsteps

--- a/ommworker.py
+++ b/ommworker.py
@@ -124,7 +124,7 @@ class OMMWorker(object):
         return (self.positions, self.velocities)
 
     # sets the reporters of the worker
-    def set_reporters(self, current_steps, outfile, logfile, dcdfile):
+    def set_reporters(self, current_steps, outfile, logfile, xtcfile):
         self._startedSignal.wait()
         self._readySignal.wait()
         self._cmdq.put("SETREPORTERS")


### PR DESCRIPTION
OpenMM 8.1 has introduced the xtc reporter, perhaps we can reduce the trajectory volume through this?