### PR TITLE
Fixed the paths in the examples

### DIFF
--- a/examples/ABFE/fkbp/scripts/setup-settings.sh
+++ b/examples/ABFE/fkbp/scripts/setup-settings.sh
@@ -16,4 +16,4 @@ displacement=("22.0" "22.0" "22.0")
 vsite_rcpt_residues=(26 36 37 42 46 48 54 55 56 82)
 
 #path to AToM-OpenMM
-AToM_dir=$HOME/Dropbox/src/AToM-OpenMM
+AToM_dir=$HOME/Dropbox/src/AToM-OpenMM/atom_openmm

--- a/examples/RBFE/cdk2/scripts/setup-settings.sh
+++ b/examples/RBFE/cdk2/scripts/setup-settings.sh
@@ -2,7 +2,7 @@
 basename=cdk2
 
 #path to AToM-OPenMM
-AToM_dir=$HOME/AToM-OpenMM
+AToM_dir=$HOME/AToM-OpenMM/atom_openmm
 
 #basename of the receptor pdb file (processed for amber using pdb4amber)
 receptor=cdk2

--- a/examples/RBFE/eralpha/scripts/setup-settings.sh
+++ b/examples/RBFE/eralpha/scripts/setup-settings.sh
@@ -3,7 +3,7 @@
 basename=eralpha
 
 #path to AToM
-AToM_dir=$HOME/Dropbox/src/AToM-OpenMM
+AToM_dir=$HOME/Dropbox/src/AToM-OpenMM/atom_openmm
 
 #basename of the receptor pdb file (processed for amber using pdb4amber)
 receptor=eralpha

--- a/examples/RBFE/temoa-g1-g4/README.md
+++ b/examples/RBFE/temoa-g1-g4/README.md
@@ -16,8 +16,8 @@ We assume in this tutorial that this repository has been cloned under `$HOME`. A
 Prepare, minimize, thermalize, relax, and equilibrate the complex:
 ```
 cd $HOME/AToM-OpenMM/examples/RBFE/temoa-g1-g4
-python $HOME/AToM-OpenMM/make_atm_system_from_Amber.py --AmberPrmtopinFile temoa-g1-g4.prmtop --AmberInpcrdinFile temoa-g1-g4.inpcrd --systemXMLoutFile temoa-g1-g4_sys.xml --systemPDBoutFile temoa-g1-g4.pdb
-python $HOME/AToM-OpenMM/rbfe_structprep.py temoa-g1-g4_asyncre.cntl
+python $HOME/AToM-OpenMM/atom_openmm/make_atm_system_from_Amber.py --AmberPrmtopinFile temoa-g1-g4.prmtop --AmberInpcrdinFile temoa-g1-g4.inpcrd --systemXMLoutFile temoa-g1-g4_sys.xml --systemPDBoutFile temoa-g1-g4.pdb
+python $HOME/AToM-OpenMM/atom_openmm/rbfe_structprep.py temoa-g1-g4_asyncre.cntl
 ```
 The lower cup of the host loosely restrained as in the original work. Each step creates an OpenMM checkpoint file in XML format to start the subsequent step. Each step also generates a PDB file for visualization. The result is an equilibrated system at the alchemical intermediate state at λ=1/2.
 
@@ -26,7 +26,7 @@ The lower cup of the host loosely restrained as in the original work. Each step 
 See the [TEMOA-G1 ABFE tutorial](https://github.com/Gallicchio-Lab/AToM-OpenMM/tree/master/examples/ABFE/temoa-g1) about the nodefile and how to customize it in different ways to match the hardware on your machine.
 
 ```
-python $HOME/AToM-OpenMM/rbfe_production.py temoa-g1-g4_asyncre.cntl
+python $HOME/AToM-OpenMM/atom_openmm/rbfe_production.py temoa-g1-g4_asyncre.cntl
 ```
 
 You should see the contents of the control file echo-ed back and messages indicating that replica are dispatched to the GPU and that replicas change alchemical states by exchanging them with other replicas. The job is set to run for 4 hours.


### PR DESCRIPTION
As suggested here: https://github.com/Gallicchio-Lab/AToM-OpenMM/pull/110#issuecomment-2899635772
This should fix all the paths to the python scripts found in the examples