### PR TITLE
CI/CD pipeline with automated tests on Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  publish:
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.9"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          channels: acellera,conda-forge
+          activate-environment: ../deploy-env
+
+      - name: Build PyPI 📦
+        run: |
+          pip install build
+          python -m build --sdist --outdir dist/ .
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test:
+    timeout-minutes: 45
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"] #, "macos-latest", "macos-13", "windows-2019"]
+        python-version: ["3.10"] #, "3.9", "3.11", "3.12"]
+
+    defaults: # Needed for conda
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: true
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+
+      - name: Lint with flake8
+        run: |
+          pip install flake8 coverage pytest-cov pytest pytest-subtests
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Install conda deps
+        run: |
+          conda install mamba
+          mamba install -y -q python=${{ matrix.python-version }} openmm openmm-ml pyyaml numpy cuda-version>=11.8 pandas
+
+      - name: Install package
+        run: |
+          pip install .
+
+      - name: List conda environment
+        run: conda list
+
+      - name: Test
+        run: |
+          pytest ./tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,14 @@
+name: CI/CD
+
+on: [push]
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+
+  publish:
+    if: startsWith(github.event.ref, 'refs/tags/')
+    needs: test
+    uses: ./.github/workflows/publish.yml
+    secrets: inherit


### PR DESCRIPTION
Added Github Actions workflows for executing the tests on Github Actions and releasing the package to PyPI.
Tests are run on every push.

Once this PR is merged you will need to set a secret in the repo settings called `PYPI_API_TOKEN` with a token which you can get from your PyPI account. This will allow Github Actions to upload your releases to PyPI.
The only thing then needed is to push a tag with a version to this repo and it will test and create the release.