### PR TITLE
identify receptor with multiple chain ids

### DIFF
--- a/examples/RBFE/cdk2/scripts/run-atm.py
+++ b/examples/RBFE/cdk2/scripts/run-atm.py
@@ -95,8 +95,9 @@ def rbfe_prepare_args(options):
     options['DISPLACEMENT'] = [ displ.x , displ.y, displ.z ] 
 
     #CM atoms of the receptor, all C-alpha atoms
-    rcpt_chain_name = options.get('RCPT_CHAIN_NAME', 'A')
-    rcpt_frame_query = f'atom.residue.chain.id == "{rcpt_chain_name}" and atom.name == "CA"'
+    rcpt_chain_names = options.get('RCPT_CHAIN_NAMES', ['A'])
+    rcpt_chain_query = f'atom.residue.chain.id in {rcpt_chain_names}'
+    rcpt_frame_query = rcpt_chain_query + ' and atom.name == "CA"'
     rcpt_frame_indexes = get_indexes_from_query(topology, rcpt_frame_query)
 
     #internal receptor frame
@@ -120,7 +121,7 @@ def rbfe_prepare_args(options):
 
     #receptor-ligand exclusion potential
     options['EXCLUSION_POT_MOL1_INDEXES'] = get_indexes_from_query(
-        topology, f'(atom.residue.chain.id == "{rcpt_chain_name}") and (atom.element.atomic_number != 1)')
+        topology, f'( {rcpt_chain_query} ) and (atom.element.atomic_number != 1)')
     options['EXCLUSION_POT_MOL2_INDEXES'] = get_indexes_from_residue(res2, query = '(atom.element.atomic_number != 1)')
 
     #working directory

--- a/examples/RBFE/protein-peptide/tiam1/scripts/defaults.yaml
+++ b/examples/RBFE/protein-peptide/tiam1/scripts/defaults.yaml
@@ -19,6 +19,7 @@
  CM_TOL: 7.5                  #tolerance of flat-bottom binding site restraint, radius in Ang
  POSRE_FORCE_CONSTANT: 25  #force constant of position restraint, in kcal/mol/Ang^2
  POSRE_TOLERANCE: 2.5       #tolerance of position restraint, radius in Ang
+ RCPT_CHAIN_NAMES: ['B']    #ids of the chains of the receptor, ['A'] if not specified 
  ALIGN_KF_SEP: 0.0          #force constant of separation component of the ligand alignment restraint, in kcal/mol/Ang^2 (zero for variable displacement mode)
  ALIGN_K_THETA: 25.0        #force constant of orientation component of the ligand alignment restraint, in kcal/mol
  ALIGN_K_PSI:   25.0        #force constant of roll component of the ligand alignment restraint, in kcal/mol

--- a/examples/RBFE/protein-peptide/tiam1/scripts/run-atm.py
+++ b/examples/RBFE/protein-peptide/tiam1/scripts/run-atm.py
@@ -54,8 +54,9 @@ def rbfe_prepare_args(options):
     positions = pdb.positions
 
     #CM atoms of the receptor, all C-alpha atoms except the protein partners
-    rcpt_chain_name = options.get('RCPT_CHAIN_NAME', 'B')
-    rcpt_frame_query = f'atom.residue.chain.id == "{rcpt_chain_name}" and atom.name == "CA"'
+    rcpt_chain_names = options.get('RCPT_CHAIN_NAMES', ['A'])
+    rcpt_chain_query = f'atom.residue.chain.id in {rcpt_chain_names}'
+    rcpt_frame_query = rcpt_chain_query + ' and atom.name == "CA"'
     rcpt_frame_indexes = get_indexes_from_query(topology, rcpt_frame_query)
 
     #internal receptor frame
@@ -103,7 +104,7 @@ def rbfe_prepare_args(options):
 
     #receptor-ligand exclusion potential
     options['EXCLUSION_POT_MOL1_INDEXES'] = get_indexes_from_query(
-        topology, f'(atom.residue.chain.id == "{rcpt_chain_name}") and (atom.residue.name != "HOH") and (atom.element.atomic_number != 1)')
+        topology, f'( {rcpt_chain_query} ) and (atom.residue.name != "HOH") and (atom.element.atomic_number != 1)')
     options['EXCLUSION_POT_MOL2_INDEXES'] = get_indexes_from_query(
         topology, '(atom.residue.chain.id == "M") and (atom.element.atomic_number != 1)')
 


### PR DESCRIPTION
Adds an RCPT_CHAIN_NAMES option to the examples settings to identify receptors with multiple chains.